### PR TITLE
Renamed reference repository for gerrit trigger

### DIFF
--- a/jenkins/jobs/dsl/chef_pipeline_jobs.template
+++ b/jenkins/jobs/dsl/chef_pipeline_jobs.template
@@ -39,7 +39,7 @@ pipelineView.with {
 chefGetCookboks.with {
     description('This job downloads a cookbook. Also job have Gerrit trigger with regexp configuration, it will catch every Git repository within "cookbook" word in name.')
     parameters {
-        stringParam('COOKBOOK', 'adop-cartridge-chef-reference', "The name of the cookbook to package i.e. nginx-cookbook - this job is invoked by a gerrit ref-updated hook")
+        stringParam('COOKBOOK', 'adop-cartridge-chef-reference-cookbook', "The name of the cookbook to package i.e. nginx-cookbook - this job is invoked by a gerrit ref-updated hook")
     }
     wrappers {
         preBuildCleanup()

--- a/src/urls.txt
+++ b/src/urls.txt
@@ -1,2 +1,2 @@
-https://github.com/accenture/adop-cartridge-chef-reference.git
+https://github.com/accenture/adop-cartridge-chef-reference-cookbook.git
 https://github.com/accenture/adop-cartridge-chef-scripts.git


### PR DESCRIPTION
The repository will also need to be renamed from https://github.com/Accenture/adop-cartridge-chef-reference to https://github.com/Accenture/adop-cartridge-chef-reference-cookbook
